### PR TITLE
feat: Made sidebar use full height of window

### DIFF
--- a/autoload/coc_explorer.vim
+++ b/autoload/coc_explorer.vim
@@ -19,11 +19,11 @@ function! coc_explorer#create(
     execute 'silent keepalt tabnew '.name
   elseif a:position ==# 'left'
     wincmd t
-    execute 'silent keepalt leftabove vsplit '.name
+    execute 'silent keepalt vertical topleft vsplit '.name
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'right'
     wincmd b
-    execute 'silent keepalt rightbelow vsplit '.name
+    execute 'silent keepalt bot vsplit '.name
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'floating'
     let floating_winid = v:null
@@ -73,11 +73,11 @@ function! coc_explorer#resume(
       \)
   if a:position ==# 'left'
     wincmd t
-    execute 'silent keepalt leftabove vertical sb '.a:bufnr
+    execute 'silent keepalt vertical topleft sb '.a:bufnr
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'right'
     wincmd b
-    execute 'silent keepalt rightbelow vertical sb '.a:bufnr
+    execute 'silent keepalt bot vertical sb '.a:bufnr
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'floating'
     if a:floating_border_enable && a:floating_border_bufnr isnot v:null

--- a/autoload/coc_explorer.vim
+++ b/autoload/coc_explorer.vim
@@ -23,7 +23,7 @@ function! coc_explorer#create(
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'right'
     wincmd b
-    execute 'silent keepalt bot vsplit '.name
+    execute 'silent keepalt vertical botright vsplit '.name
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'floating'
     let floating_winid = v:null
@@ -77,7 +77,7 @@ function! coc_explorer#resume(
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'right'
     wincmd b
-    execute 'silent keepalt bot vertical sb '.a:bufnr
+    execute 'silent keepalt vertical botright sb '.a:bufnr
     call coc_explorer#resize_win(a:position, a:width)
   elseif a:position ==# 'floating'
     if a:floating_border_enable && a:floating_border_bufnr isnot v:null


### PR DESCRIPTION
When using two splits the explorer window will open on the top split instead of spanning the height of the screen.

Before:
![1589647936](https://user-images.githubusercontent.com/11710109/82125511-07b84380-976c-11ea-8514-f10cb09bb69c.png)

After:
![1589647838](https://user-images.githubusercontent.com/11710109/82125518-1272d880-976c-11ea-9332-2a01dbe0d5df.png)
