### PR TITLE
feat: Option to display floating window centred at the top

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,8 @@
               "enum": [
                 "left-center",
                 "right-center",
-                "center"
+                "center",
+                "center-top"
               ]
             },
             {

--- a/readme.md
+++ b/readme.md
@@ -173,6 +173,7 @@ Explorer position for floating window, positions:
 - `left-center`
 - `center`
 - `right-center`
+- `center-top`
 - `<number for left>,<number for top>`
 
 default: `center`
@@ -360,7 +361,7 @@ Default: <pre><code>0</code></pre>
 Default: <pre><code>"vim-width"</code></pre>
 </details>
 <details>
-<summary><code>explorer.floating.position</code>: Position of Explorer for floating window. type: <code>"left-center" | "right-center" | "center" | integer</code></summary>
+<summary><code>explorer.floating.position</code>: Position of Explorer for floating window. type: <code>"left-center" | "right-center" | "center" | "center-top" | integer</code></summary>
 Default: <pre><code>"center"</code></pre>
 </details>
 <details>

--- a/src/argOptions.ts
+++ b/src/argOptions.ts
@@ -83,7 +83,7 @@ export const argOptions = {
     ArgFloatingPositions | [number, number]
   >('floating-position', {
     parseArg: (s) => {
-      if (['left-center', 'right-center', 'center'].includes(s)) {
+      if (['left-center', 'right-center', 'center', 'center-top'].includes(s)) {
         return s as ArgFloatingPositions;
       } else {
         return s.split(',').map((i) => parseInt(i, 10)) as [number, number];

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -99,6 +99,9 @@ export class Explorer {
       } else if (floatingPosition === 'right-center') {
         left = vimWidth - width;
         top = (vimHeight - height) / 2;
+      } else if (floatingPosition === 'center-top') {
+        left = (vimWidth - width) / 2;
+        top = 1;
       } else {
         [left, top] = floatingPosition;
       }

--- a/src/parseArgs.ts
+++ b/src/parseArgs.ts
@@ -33,7 +33,7 @@ export type ArgOptionRequired<T> = {
 
 export type ArgContentWidthTypes = 'win-width' | 'vim-width';
 
-export type ArgFloatingPositions = 'left-center' | 'right-center' | 'center';
+export type ArgFloatingPositions = 'left-center' | 'right-center' | 'center' | 'center-top';
 
 export class Args {
   private static registeredOptions: Map<string, ArgOption<any>> = new Map();


### PR DESCRIPTION
Added option  to `"explorer.floating.position"` to display floating window at the top of vim, but centred horizontally.
<img width="1792" alt="Screenshot 2020-06-07 at 22 11 53" src="https://user-images.githubusercontent.com/1163040/83975431-63aa5e00-a90d-11ea-8779-e72e57cc9621.png">
