### PR TITLE
feat: Option for hiding floating window, when opening CocList

### DIFF
--- a/package.json
+++ b/package.json
@@ -280,6 +280,11 @@
           "type": "string",
           "default": "coc-explorer"
         },
+        "explorer.floating.hideForActionList": {
+          "description": "Hide floating window, when opening action list",
+          "type": "boolean",
+          "default": true
+        },
         "explorer.autoExpandMaxDepth": {
           "description": "Automatically expand maximum depth of one time",
           "type": "integer",

--- a/package.json
+++ b/package.json
@@ -280,8 +280,8 @@
           "type": "string",
           "default": "coc-explorer"
         },
-        "explorer.floating.hideForActionList": {
-          "description": "Hide floating window, when opening action list",
+        "explorer.floating.hideOnCocList": {
+          "description": "Hide floating window, when opening CocList",
           "type": "boolean",
           "default": true
         },

--- a/readme.md
+++ b/readme.md
@@ -398,6 +398,10 @@ Default: <pre><code>[
 Default: <pre><code>"coc-explorer"</code></pre>
 </details>
 <details>
+<summary><code>explorer.floating.hideForActionList</code>: Hide floating window, when opening action list. type: <code>boolean</code></summary>
+Default: <pre><code>true</code></pre>
+</details>
+<details>
 <summary><code>explorer.autoExpandMaxDepth</code>: Automatically expand maximum depth of one time. type: <code>integer</code></summary>
 Default: <pre><code>20</code></pre>
 </details>

--- a/readme.md
+++ b/readme.md
@@ -398,7 +398,7 @@ Default: <pre><code>[
 Default: <pre><code>"coc-explorer"</code></pre>
 </details>
 <details>
-<summary><code>explorer.floating.hideForActionList</code>: Hide floating window, when opening action list. type: <code>boolean</code></summary>
+<summary><code>explorer.floating.hideOnCocList</code>: Hide floating window, when opening CocList. type: <code>boolean</code></summary>
 Default: <pre><code>true</code></pre>
 </details>
 <details>

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -581,7 +581,9 @@ export abstract class ExplorerSource<TreeNode extends BaseTreeNode<TreeNode>> {
   async startCocList(list: IList) {
     const isFloating =
       (await this.explorer.args.value(argOptions.position)) === 'floating';
-    if (isFloating) {
+    const floatingHideForActionList = this.config.get('floating.hideForActionList', true);
+
+    if (isFloating && floatingHideForActionList) {
       await this.explorer.hide();
     }
 

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -583,11 +583,12 @@ export abstract class ExplorerSource<TreeNode extends BaseTreeNode<TreeNode>> {
       (await this.explorer.args.value(argOptions.position)) === 'floating';
     const floatingHideForActionList = this.config.get('floating.hideForActionList', true);
 
+    let isShown = true;
     if (isFloating && floatingHideForActionList) {
       await this.explorer.hide();
+      isShown = false;
     }
 
-    let isShown = isFloating ? false : true;
     const shownExplorerEmitter = new Emitter<void>();
     const disposable = listManager.registerList(list);
     await listManager.start([list.name]);

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -581,7 +581,7 @@ export abstract class ExplorerSource<TreeNode extends BaseTreeNode<TreeNode>> {
   async startCocList(list: IList) {
     const isFloating =
       (await this.explorer.args.value(argOptions.position)) === 'floating';
-    const floatingHideForActionList = this.config.get('floating.hideForActionList', true);
+    const floatingHideForActionList = this.config.get('floating.hideOnCocList', true);
 
     let isShown = true;
     if (isFloating && floatingHideForActionList) {

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -581,10 +581,10 @@ export abstract class ExplorerSource<TreeNode extends BaseTreeNode<TreeNode>> {
   async startCocList(list: IList) {
     const isFloating =
       (await this.explorer.args.value(argOptions.position)) === 'floating';
-    const floatingHideForActionList = this.config.get('floating.hideOnCocList', true);
+    const floatingHideOnCocList = this.config.get('floating.hideOnCocList', true);
 
     let isShown = true;
-    if (isFloating && floatingHideForActionList) {
+    if (isFloating && floatingHideOnCocList) {
       await this.explorer.hide();
       isShown = false;
     }


### PR DESCRIPTION
Added option (`"explorer.floating.hideForActionList": true`) for hiding floating window, when user opens action list. By default it is set to `true`, so it will work same as it worked before. But this allows to change this behaviour via config.

As I understood hiding was done to eliminate overlapping between action list and floating window, but I use it with `"explorer.floating.position": "center-top"`, so it does not overlap. And it's handy to see what directory I am hovering over, when selecting actions from the action list. And it reduces flickering, cause there is no close/open cycle.

I am not sure if i chose the right option name for this, feel free to correct me :)

P.S.
it looks like this
<img width="1792" alt="Screenshot 2020-06-08 at 12 57 22" src="https://user-images.githubusercontent.com/1163040/84006119-a872db00-a987-11ea-99d5-212f336c8442.png">
