### PR TITLE
fix: Hide cursorline in the background floating window

### DIFF
--- a/autoload/coc_explorer.vim
+++ b/autoload/coc_explorer.vim
@@ -175,8 +175,7 @@ function! coc_explorer#init_buf(is_border)
               \ noswapfile noundofile
               \ nomodeline
               \ signcolumn=no
-              \ nocursorline
-              \ nocursorcolumn
+              \ nocursorcolumn nocursorline
               \ nofoldenable foldcolumn=0
               \ nonumber norelativenumber
               \ nospell

--- a/autoload/coc_explorer.vim
+++ b/autoload/coc_explorer.vim
@@ -175,6 +175,7 @@ function! coc_explorer#init_buf(is_border)
               \ noswapfile noundofile
               \ nomodeline
               \ signcolumn=no
+              \ nocursorline
               \ nocursorcolumn
               \ nofoldenable foldcolumn=0
               \ nonumber norelativenumber

--- a/src/explorer.ts
+++ b/src/explorer.ts
@@ -101,7 +101,7 @@ export class Explorer {
         top = (vimHeight - height) / 2;
       } else if (floatingPosition === 'center-top') {
         left = (vimWidth - width) / 2;
-        top = 1;
+        top = 0;
       } else {
         [left, top] = floatingPosition;
       }


### PR DESCRIPTION
At first I thought it was some weird highlighting, but it was just a cursor line in background buffer. 
I changed floating window position as well so it would be more default.

before (_look at the first line in floating window buffer_)
<img width="726" alt="Screenshot 2020-06-08 at 15 38 30" src="https://user-images.githubusercontent.com/1163040/84022267-69508400-a99f-11ea-8c75-74f6bee4e689.png">
after
<img width="726" alt="Screenshot 2020-06-08 at 15 43 30" src="https://user-images.githubusercontent.com/1163040/84022292-74a3af80-a99f-11ea-91d7-d6d7f20f0bfb.png">
I hope I'am not bothering you :)