### PR TITLE
Append to runtimepath instead of prepend

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ export const activate = async (context: ExtensionContext) => {
     const paths = rtp.split(',');
     if (!paths.includes(context.extensionPath)) {
       await nvim.command(
-        `execute 'noa set rtp^='.fnameescape('${context.extensionPath.replace(
+        `execute 'noa set rtp+='.fnameescape('${context.extensionPath.replace(
           /'/g,
           "''",
         )}')`,


### PR DESCRIPTION
If we prepend coc-explorer to vim `runtimepath`, it will mess up spellfile generation because it is the first dir in vim `runtimepath`. But clearly we don't want to put spellfile under coc-explorer directory