### PR TITLE
Respect splitright

### DIFF
--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -685,15 +685,7 @@ export abstract class ExplorerSource<TreeNode extends BaseTreeNode<TreeNode>>
       },
       vsplit: async () => {
         nvim.pauseNotification();
-        nvim.command(`vsplit ${await getEscapePath()}`, true);
-        const position = await this.explorer.args.value(argOptions.position);
-        if (position === 'left') {
-          nvim.command('wincmd L', true);
-        } else if (position === 'right') {
-          nvim.command('wincmd H', true);
-        } else if (position === 'tab') {
-          nvim.command('wincmd L', true);
-        }
+        nvim.command(`wincmd p | vsplit ${await getEscapePath()}`, true);
         jumpToNotify();
         (await this.explorer.tryQuitOnOpenNotifier()).notify();
         await nvim.resumeNotification();


### PR DESCRIPTION
d0210bb5fecfeae58d82a65cfb55f5dffb088052 introduced the behavior to always
move a vertical split to the extreme left, when coc-explorer is on the
right (and vice-versa). This fix the problem of having the coc-explorer
window not fixed on the 'left' or 'right' of vim, but it does not
respect the vim splitright option.

To make the split behavior more predictable, instead of opening the file
from the coc-explorer window, open it from the last window perspective.
This way coc-explorer will respect any split/vsplit options.

Fixes: https://github.com/weirongxu/coc-explorer/issues/256