### PR TITLE
Add Toggle to allow showing only git changed files

### DIFF
--- a/package.json
+++ b/package.json
@@ -655,6 +655,11 @@
           "type": "boolean",
           "default": false
         },
+        "explorer.file.showOnlyGitChange": {
+          "description": "Default show only git changed files",
+          "type": "boolean",
+          "default": false
+        },
         "explorer.file.root.template": {
           "description": "Template for root node of file source",
           "type": "string",

--- a/readme.md
+++ b/readme.md
@@ -649,6 +649,10 @@ Default: <pre><code>{
 Default: <pre><code>false</code></pre>
 </details>
 <details>
+<summary><code>explorer.file.showOnlyGitChange</code>: Default show only git changed files. type: <code>boolean</code></summary>
+Default: <pre><code>false</code></pre>
+</details>
+<details>
 <summary><code>explorer.file.root.template</code>: Template for root node of file source. type: <code>string</code></summary>
 Default: <pre><code>"[icon] [title] [hidden & 1][root] [fullpath]"</code></pre>
 </details>

--- a/src/mappings.ts
+++ b/src/mappings.ts
@@ -63,6 +63,7 @@ const defaultMappingGroups: Record<
     r: 'rename',
 
     '.': 'toggleHidden',
+    gt: 'toggleOnlyGitChange',
     R: 'refresh',
 
     '?': 'help',

--- a/src/source/source.ts
+++ b/src/source/source.ts
@@ -146,6 +146,7 @@ export abstract class ExplorerSource<TreeNode extends BaseTreeNode<TreeNode>>
   width: number = 0;
   flattenedNodes: TreeNode[] = [];
   showHidden: boolean = false;
+  showOnlyGitChange: boolean = false;
   selectedNodes: Set<TreeNode> = new Set();
   rootExpanded = false;
   nvim = workspace.nvim;
@@ -362,6 +363,14 @@ export abstract class ExplorerSource<TreeNode extends BaseTreeNode<TreeNode>>
         this.showHidden = !this.showHidden;
       },
       'toggle visibility of hidden node',
+      { reload: true },
+    );
+    this.addNodeAction(
+      'toggleOnlyGitChange',
+      async () => {
+        this.showOnlyGitChange = !this.showOnlyGitChange;
+      },
+      'toggle visibility of git change node',
       { reload: true },
     );
     this.addNodeAction(

--- a/src/source/sources/file/fileActions.ts
+++ b/src/source/sources/file/fileActions.ts
@@ -33,9 +33,9 @@ export function initFileActions(file: FileSource) {
       }
       const nodeUid = file.currentNode()?.uid;
       if (/^[A-Za-z]:[\\\/]$/.test(file.root)) {
-        file.root = '';
+        await file.setRoot('');
       } else {
-        file.root = pathLib.dirname(file.root);
+        await file.setRoot(pathLib.dirname(file.root));
         await file.cd(file.root);
       }
       await file.expand(file.rootNode);
@@ -150,7 +150,7 @@ export function initFileActions(file: FileSource) {
     async ({ node, args }) => {
       const cdTo = async (fullpath: string) => {
         await file.cd(fullpath);
-        file.root = fullpath;
+        await file.setRoot(fullpath);
         await file.expand(file.rootNode);
       };
       const path = args[0];
@@ -557,7 +557,7 @@ export function initFileActions(file: FileSource) {
           drives.map((drive) => ({
             name: drive,
             callback: async (drive) => {
-              file.root = drive;
+              await file.setRoot(drive);
               await file.expand(file.rootNode);
             },
           })),


### PR DESCRIPTION
This feature really helpful when it comes to review code at local, which similar to show file tree of a git commit on intelliJ. This PR simply allow us toggle to show only git changed files. 