### PR TITLE
Clarified the builtin help

### DIFF
--- a/src/actions/globalActions.ts
+++ b/src/actions/globalActions.ts
@@ -522,6 +522,8 @@ export function loadGlobalActions(action: ActionExplorer) {
         'toggle:labeling': 'toggle labeling',
         'toggle:labeling:200': 'toggle labeling with debounce',
         'toggle:content': 'toggle content',
+        'enable:content': 'enable with content',
+        'enable:labeling': 'enable with labeling',
       },
     },
   );


### PR DESCRIPTION
`previewOnHover:enable` needs an argument which is nowhere truly said in the help