### PR TITLE
feat: add "explorer.enable" option

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,11 @@
       "type": "object",
       "title": "Explorer",
       "properties": {
+        "explorer.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable coc-explorer extension"
+        },
         "explorer.presets": {
           "description": "Explorer presets",
           "type": "object",

--- a/readme.md
+++ b/readme.md
@@ -630,6 +630,10 @@ Type: <pre><code>'keep' | 'workspace' | 'cwd' | 'sourceBuffer' | 'reveal'</code>
 </details>
 <strong>Properties</strong>
 <details>
+<summary><code>explorer.enable</code>: Enable coc-explorer extension.</summary>
+Type: <pre><code>boolean</code></pre>Default: <pre><code>true</code></pre>
+</details>
+<details>
 <summary><code>explorer.presets</code>: Explorer presets.</summary>
 Type: <pre><code>{
     [k: string]: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,10 +16,10 @@ import { hlGroupManager } from './highlight/manager';
 import { PresetList } from './lists/presets';
 import { asyncCatchError, logger, registerRuntimepath } from './util';
 import { registerVimApi } from './vimApi';
+import { config } from './config';
 
 export const activate = (context: ExtensionContext) => {
-  const extCfg = workspace.getConfiguration('explorer');
-  const isEnable = extCfg.get<boolean>('enable', true);
+  const isEnable = config.get('enable', true);
   if (!isEnable) return;
 
   const { subscriptions } = context;

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,10 @@ import { asyncCatchError, logger, registerRuntimepath } from './util';
 import { registerVimApi } from './vimApi';
 
 export const activate = (context: ExtensionContext) => {
+  const extCfg = workspace.getConfiguration('explorer');
+  const isEnable = extCfg.get<boolean>('enable', true);
+  if (!isEnable) return;
+
   const { subscriptions } = context;
   const { nvim } = workspace;
 

--- a/src/types/pkg-config.d.ts
+++ b/src/types/pkg-config.d.ts
@@ -22,6 +22,10 @@ export type RootStrategy = 'keep' | 'workspace' | 'cwd' | 'sourceBuffer' | 'reve
 
 export interface Explorer {
   /**
+   * Enable coc-explorer extension
+   */
+  'explorer.enable'?: boolean;
+  /**
    * Explorer presets
    */
   'explorer.presets'?: {


### PR DESCRIPTION
## Description

Due to the nature of `coc-explorer`, it outputs a lot of logs in `:CocInfo` and coc debug logs.

I'm developing some coc extensions, I uninstall `coc-explorer` every time I want to check other coc extensions in detail.

I thought it would be useful to have an option to enable/disable.

## Misc

If you do not intend to provide the enable/disable option, you can close this PR. 🙇