### PR TITLE
Improved message readability when renaming a file.

### DIFF
--- a/src/source/sources/file/fileActions.ts
+++ b/src/source/sources/file/fileActions.ts
@@ -649,13 +649,13 @@ export function loadFileActions(action: ActionSource<FileSource, FileNode>) {
       let path = node.fullpath.replace(cwd, '')
       let renameInCwd = path !== node.fullpath
 
-      let targetPath;
       targetPath = await input(
           `Rename: `,
           path,
           "file"
       );
       
+      targetPath = targetPath?.trim();
       targetPath = targetPath == null ? void 0 : targetPath.trim();
       if (!targetPath) {
           return;

--- a/src/source/sources/file/fileActions.ts
+++ b/src/source/sources/file/fileActions.ts
@@ -306,8 +306,8 @@ export function loadFileActions(action: ActionSource<FileSource, FileNode>) {
       await file.copyToClipboard(
         nodes
           ? nodes
-              .map((it) => pathLib.relative(file.root, it.fullpath))
-              .join('\n')
+            .map((it) => pathLib.relative(file.root, it.fullpath))
+            .join('\n')
           : file.root,
       );
       await window.showInformationMessage(
@@ -645,16 +645,12 @@ export function loadFileActions(action: ActionSource<FileSource, FileNode>) {
 
       let targetPath: string | undefined;
 
-      const cwd = await nvim.call('getcwd');
-      const path = node.fullpath.replace(cwd, '');
-      const renameInCwd = path !== node.fullpath;
+      const cwd: string = await nvim.call('getcwd');
+      const path: string = node.fullpath.replace(cwd, '');
+      const renameInCwd: boolean = path !== node.fullpath;
 
-      targetPath = await input(
-        `Rename: `,
-        path,
-        "file"
-      );
-      
+      targetPath = await input(`Rename: `, path, 'file');
+
       targetPath = targetPath?.trim();
       targetPath = targetPath == null ? void 0 : targetPath.trim();
       if (!targetPath) {
@@ -662,8 +658,9 @@ export function loadFileActions(action: ActionSource<FileSource, FileNode>) {
       }
 
       if (renameInCwd) {
-          targetPath = cwd + targetPath
+        targetPath = cwd + targetPath;
       }
+
       await overwritePrompt(
         'rename',
         [

--- a/src/source/sources/file/fileActions.ts
+++ b/src/source/sources/file/fileActions.ts
@@ -645,22 +645,22 @@ export function loadFileActions(action: ActionSource<FileSource, FileNode>) {
 
       let targetPath: string | undefined;
 
-      let cwd = await nvim.call('getcwd')
-      let path = node.fullpath.replace(cwd, '')
-      let renameInCwd = path !== node.fullpath
+      const cwd = await nvim.call('getcwd');
+      const path = node.fullpath.replace(cwd, '');
+      const renameInCwd = path !== node.fullpath;
 
       targetPath = await input(
-          `Rename: `,
-          path,
-          "file"
+        `Rename: `,
+        path,
+        "file"
       );
       
       targetPath = targetPath?.trim();
       targetPath = targetPath == null ? void 0 : targetPath.trim();
       if (!targetPath) {
-          return;
+        return;
       }
-      
+
       if (renameInCwd) {
           targetPath = cwd + targetPath
       }

--- a/src/source/sources/file/fileActions.ts
+++ b/src/source/sources/file/fileActions.ts
@@ -645,17 +645,25 @@ export function loadFileActions(action: ActionSource<FileSource, FileNode>) {
 
       let targetPath: string | undefined;
 
+      let cwd = await nvim.call('getcwd')
+      let path = node.fullpath.replace(cwd, '')
+      let renameInCwd = path !== node.fullpath
+
+      let targetPath;
       targetPath = await input(
-        `Rename: ${node.fullpath} ->`,
-        node.fullpath,
-        'file',
+          `Rename: `,
+          path,
+          "file"
       );
-
-      targetPath = targetPath?.trim();
+      
+      targetPath = targetPath == null ? void 0 : targetPath.trim();
       if (!targetPath) {
-        return;
+          return;
       }
-
+      
+      if (renameInCwd) {
+          targetPath = cwd + targetPath
+      }
       await overwritePrompt(
         'rename',
         [


### PR DESCRIPTION
This pull request is related to : #569

I removed the duplicated display of the filename to be renamed.

I also added additional logic when the rename file is in the current directory, the display is even clearer since it only displays the directories of the current project.